### PR TITLE
Retire Moire and point rusqlite-facet to Facet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # moire (mwah-ray)
 
+> [!IMPORTANT]
+> Moire is retired. The reusable SQLite integration crate, `rusqlite-facet`, has
+> moved to the Facet monorepo:
+> <https://github.com/facet-rs/facet/tree/main/rusqlite-facet>.
+>
+> Please open future `rusqlite-facet` issues and pull requests in
+> <https://github.com/facet-rs/facet>. The remaining Moire crates and tooling are
+> not being maintained.
+
 runtime graph instrumentation for tokio-based Rust systems.
 
 moiré replaces Tokio's primitives with named, instrumented wrappers. At every


### PR DESCRIPTION
## Summary

Adds a top-level retirement notice to Moire's README.

The notice points `rusqlite-facet` users to its new home in the Facet monorepo:
https://github.com/facet-rs/facet/tree/main/rusqlite-facet

It also makes clear that the remaining Moire crates and tooling are no longer maintained.

## Testing

- repository pre-push checks passed
